### PR TITLE
Add Ubuntu 26.04 development image

### DIFF
--- a/build_ubuntu_26_04.sh
+++ b/build_ubuntu_26_04.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+docker build -t kaspernj/rails-development-base-ubuntu-26-04 image_ubuntu_26_04/

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,10 +1,23 @@
 services:
   web:
-    image: "kaspernj/rails-development-base-ubuntu-25-10"
+    image: "kaspernj/rails-development-base-ubuntu-26-04"
     depends_on:
+      - docker_server
       - mariadb
       - postgres
       - redis
+    devices:
+      - "/dev/kvm:/dev/kvm"
+    device_cgroup_rules:
+      - "c 10:232 rwm"
+    group_add:
+      - "${HOST_KVM_GID:-109}"
+    healthcheck:
+      test: ["CMD-SHELL", "test -r /dev/kvm -a -w /dev/kvm"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
     mem_limit: 8G
     networks:
       default:
@@ -21,14 +34,22 @@ services:
       - "${HOST_HOME}/.codex/skills:/home/dev/.claude/skills"
       - "${HOST_HOME}/.config/claude/agents:/home/dev/.claude/agents"
       - "${HOST_HOME}/.config/claude/agents:/home/dev/.config/claude/agents"
+
   mariadb:
     image: "mariadb:latest"
     environment:
-      MYSQL_DATABASE: "database-name"
-      MYSQL_ROOT_HOST: "%"
-      MYSQL_ROOT_PASSWORD: topsecret
-      MYSQL_USER: dev
-      MYSQL_PASSWORD: secret
+      MARIADB_AUTO_UPGRADE: "true"
+      MARIADB_DATABASE: "database-name"
+      MARIADB_ROOT_HOST: "%"
+      MARIADB_ROOT_PASSWORD: topsecret
+      MARIADB_USER: dev
+      MARIADB_PASSWORD: secret
+    healthcheck:
+      test: ["CMD-SHELL", "mariadb-admin ping -h 127.0.0.1 -u root -p$$MARIADB_ROOT_PASSWORD --silent"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
     expose:
       - 3306
     mem_limit: 4G
@@ -42,6 +63,7 @@ services:
         hard: "262144"
     volumes:
       - mariadb:/var/lib/mysql
+
   postgres:
     image: "postgres"
     expose:
@@ -50,6 +72,12 @@ services:
       POSTGRES_USER: "username"
       POSTGRES_PASSWORD: "password"
       POSTGRES_DB: "database-name"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
     mem_limit: 4G
     networks:
       default:
@@ -57,10 +85,17 @@ services:
     restart: unless-stopped
     volumes:
       - postgres:/var/lib/postgresql/data
+
   redis:
     image: "redis"
     expose:
       - 6379
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
     mem_limit: 2G
     networks:
       default:
@@ -68,11 +103,18 @@ services:
     restart: unless-stopped
     volumes:
       - redis:/var/lib/redis/data
+
   docker_server:
     image: "docker:dind"
     command: dockerd-entrypoint.sh --group 1000 --tlsverify --tlscacert=/docker-test-certificates/tlscacert.pem --tlscert=/docker-test-certificates/tlscert.pem --tlskey=/docker-test-certificates/tlskey.pem -H tcp://0.0.0.0:5676 --registry-mirror=http://registry-cache:5000 --insecure-registry=registry-cache:5000
     expose:
       - 5676
+    healthcheck:
+      test: ["CMD-SHELL", "docker --host tcp://127.0.0.1:5676 --tlsverify --tlscacert=/docker-test-certificates/tlscacert.pem --tlscert=/docker-test-certificates/tlscert.pem --tlskey=/docker-test-certificates/tlskey.pem info >/dev/null"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
     networks:
       default:
         ipv4_address: 38.0.0.6
@@ -81,6 +123,7 @@ services:
     volumes:
       - docker:/var/lib/docker
       - "./shared/docker-test-certificates:/docker-test-certificates"
+
   registry-cache:
     image: registry:3
     restart: unless-stopped
@@ -90,18 +133,27 @@ services:
       REGISTRY_STORAGE_DELETE_ENABLED: "true"
       REGISTRY_LOG_LEVEL: info
       OTEL_TRACES_EXPORTER: none
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://127.0.0.1:5000/v2/"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
     volumes:
       - ./registry-data:/var/lib/registry
     networks:
       default:
-        ipv4_address: 6.0.0.9
+        ipv4_address: 38.0.0.9
+
 networks:
   default:
     ipam:
       driver: default
       config:
         - subnet: 38.0.0.0/16
+
 volumes:
+  docker:
   homedev:
   mariadb:
   redis:

--- a/docker-hub-push-26_04.sh
+++ b/docker-hub-push-26_04.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+docker push kaspernj/rails-development-base-ubuntu-26-04

--- a/image_ubuntu_26_04/.rvmrc
+++ b/image_ubuntu_26_04/.rvmrc
@@ -1,0 +1,1 @@
+rvm_install_on_use_flag=1

--- a/image_ubuntu_26_04/Dockerfile
+++ b/image_ubuntu_26_04/Dockerfile
@@ -1,0 +1,135 @@
+FROM ubuntu:26.04
+
+ENV LANGUAGE=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV PATH=/home/dev/.local/bin:$PATH
+ENV DEBIAN_FRONTEND=noninteractive
+
+ADD entrypoint.sh /usr/local/bin/entrypoint.sh
+ADD apt-preferences-d-firefox /etc/apt/preferences.d/mozilla-firefox
+
+# Auto install Rubies
+ADD .rvmrc /home/dev/.rvmrc
+
+RUN chmod +x /usr/local/bin/entrypoint.sh && \
+  apt-get update && apt-get install -y --force-yes apt-utils wget curl && apt-get clean && \
+
+# Locale install
+  apt-get update && apt-get install -y --force-yes locales && apt-get clean && \
+  locale-gen "en_US.UTF-8" && \
+
+# Postgres tools
+  apt-get update && apt-get install -y --force-yes postgresql-client && \
+  apt-get clean && \
+
+# Install base apps and packages
+  apt-get update && apt-get install -y --force-yes debfoster git gitg nano \
+  cron openssh-server regexxer software-properties-common ruby ruby-dev git-core screen \
+  sudo thunar \
+
+# Codex tools
+  git ripgrep sed grep coreutils findutils diffutils \
+  gh glab jq curl ca-certificates \
+  less file procps iproute2 \
+  tar gzip bzip2 xz-utils unzip zip bubblewrap \
+  build-essential make pkg-config \
+  python3 python3-pip \
+  openssh-client rsync tree fd-find bat && \
+
+  apt-get clean && \
+  deluser --remove-home ubuntu && \
+
+
+# Firefox
+  add-apt-repository ppa:mozillateam/ppa && \
+  apt-get update && apt-get install -y --force-yes firefox && \
+  apt-get clean && \
+
+# Dev user
+  echo "Configure dev user" && \
+  /usr/sbin/useradd -s /bin/bash -m dev && \
+  chown dev:dev -R /home/dev && \
+  /bin/bash -lc 'echo '\''export PATH="$HOME/.local/bin:$PATH"'\'' >> /home/dev/.profile' && \
+  chown dev:dev /home/dev/.profile && \
+
+# Use auth keys to access SSH in shared/ssh/authorized_keys instead of a password
+#   echo "dev:password" | chpasswd && \
+
+  echo "Configure SSH" && \
+  mkdir /home/dev/.ssh && \
+  chmod 700 /home/dev/.ssh && \
+  chown -R dev:dev /home/dev/.ssh && \
+  ln -s /shared/ssh/config /home/dev/.ssh/config && \
+  ln -s /shared/ssh/authorized_keys /home/dev/.ssh/authorized_keys && \
+  mv /etc/ssh/sshd_config /etc/ssh/sshd_config.original && \
+  ln -s /shared/ssh/sshd_config /etc/ssh/sshd_config && \
+
+# Heroku CLI doesn't support 24.10 yet
+#  echo "Install Heroku CLI" && \
+#   curl https://cli-assets.heroku.com/install-ubuntu.sh | sh && \
+
+# This repo doesn't have a 24.10 version yet
+#  echo "Install Java" && \
+#  apt-get install -y --force-yes software-properties-common && apt-get clean && \
+#  add-apt-repository ppa:linuxuprising/java && \
+#  /bin/bash -c "echo debconf shared/accepted-oracle-license-v1-3 select true | debconf-set-selections" && \
+#  /bin/bash -c "echo debconf shared/accepted-oracle-license-v1-3 seen true | debconf-set-selections" && \
+#  apt-get update && apt-get install -y --force-yes oracle-java17-installer && apt-get clean && \
+
+  echo "Install NodeJS" && \
+  curl -fsSL https://deb.nodesource.com/setup_current.x | sudo -E bash - && \
+  apt-get update && apt-get install -y --force-yes nodejs && \
+
+  echo "Install latest npm" && \
+  npm install --global npm && \
+  echo "Install Codex CLI for dev user" && \
+  su dev -c "mkdir -p /home/dev/.local" && \
+  su dev -c "NPM_CONFIG_PREFIX=/home/dev/.local npm install --global @openai/codex" && \
+  echo "Install Claude CLI via Anthropic's native installer" && \
+  su dev -c "curl -fsSL https://claude.ai/install.sh | bash -s latest" && \
+  ln -sf /home/dev/.local/bin/claude /usr/local/bin/claude && \
+
+  echo "Install Yarn" && \
+  npm install --global yarn && \
+
+# Build deps for the Ruby and various gems
+  apt-get update && apt-get install -y --force-yes build-essential automake bison autoconf pkg-config \
+  openssl libssl-dev zlib1g zlib1g-dev libyaml-dev git-core curl gawk g++ gcc make \
+  libc6-dev libreadline6-dev libgdbm-dev libncurses5-dev libtool libffi-dev \
+  libxslt-dev libxml2-dev libmysqlclient-dev mariadb-client libmagick++-dev imagemagick \
+  libsqlite3-dev sqlite3 libpq-dev gstreamer1.0-plugins-base \
+  gstreamer1.0-tools gstreamer1.0-x libcurl4-openssl-dev xvfb firefox-geckodriver && \
+  apt-get clean && \
+
+# ActiveStorage preview stuff
+  apt-get update && apt-get install -y ffmpeg libpoppler-glib-dev libvips42 poppler-utils && \
+
+# Install RVM
+  apt-get install -y --force-yes dirmngr && \
+  su dev -c "gpg --keyserver keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB" && \
+  su dev -c "curl -sSL https://get.rvm.io | bash" && \
+
+  echo "Install Chrome" && \
+  apt-get install -y --force-yes libxss1 libindicator7 && \
+  wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
+  /bin/bash -c "dpkg -i google-chrome*.deb; exit 0" && \
+  apt-get install -f -y --force-yes && \
+  apt-get clean && \
+  rm google-chrome-stable_current_amd64.deb && \
+
+  echo "Install ChromeDriver" && \
+  apt-get install -y --force-yes fonts-liberation unzip xdg-utils && \
+  apt-get clean && \
+  wget -N http://chromedriver.storage.googleapis.com/`curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE`/chromedriver_linux64.zip -P ~/ && \
+  unzip ~/chromedriver_linux64.zip -d ~/ && \
+  rm ~/chromedriver_linux64.zip && \
+  mv -f ~/chromedriver /usr/local/bin/chromedriver && \
+  chown root:root /usr/local/bin/chromedriver && \
+  chmod 0755 /usr/local/bin/chromedriver && \
+
+  echo "Preparing home dir to be moved into mount on first boot" && \
+  mv /home/dev /home/dev-sample
+
+# Add the entrypoint
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/image_ubuntu_26_04/Dockerfile
+++ b/image_ubuntu_26_04/Dockerfile
@@ -121,10 +121,13 @@ RUN chmod +x /usr/local/bin/entrypoint.sh && \
   echo "Install ChromeDriver" && \
   apt-get install -y --force-yes fonts-liberation unzip xdg-utils && \
   apt-get clean && \
-  wget -N http://chromedriver.storage.googleapis.com/`curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE`/chromedriver_linux64.zip -P ~/ && \
-  unzip ~/chromedriver_linux64.zip -d ~/ && \
-  rm ~/chromedriver_linux64.zip && \
-  mv -f ~/chromedriver /usr/local/bin/chromedriver && \
+  CHROME_MAJOR="$(google-chrome --product-version | cut -d. -f1)" && \
+  CHROMEDRIVER_VERSION="$(curl -fsSL "https://googlechromelabs.github.io/chrome-for-testing/LATEST_RELEASE_${CHROME_MAJOR}")" && \
+  wget -N "https://storage.googleapis.com/chrome-for-testing-public/${CHROMEDRIVER_VERSION}/linux64/chromedriver-linux64.zip" -P ~/ && \
+  unzip ~/chromedriver-linux64.zip -d ~/ && \
+  rm ~/chromedriver-linux64.zip && \
+  mv -f ~/chromedriver-linux64/chromedriver /usr/local/bin/chromedriver && \
+  rm -rf ~/chromedriver-linux64 && \
   chown root:root /usr/local/bin/chromedriver && \
   chmod 0755 /usr/local/bin/chromedriver && \
 

--- a/image_ubuntu_26_04/apt-preferences-d-firefox
+++ b/image_ubuntu_26_04/apt-preferences-d-firefox
@@ -1,0 +1,7 @@
+Package: *
+Pin: release o=LP-PPA-mozillateam
+Pin-Priority: 1001
+
+Package: firefox
+Pin: version 1:1snap*
+Pin-Priority: -1

--- a/image_ubuntu_26_04/entrypoint.sh
+++ b/image_ubuntu_26_04/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo Starting container
+ruby /shared/scripts/entrypoint.rb


### PR DESCRIPTION
## Summary
- add Ubuntu 26.04 build and Docker Hub push scripts
- add the Ubuntu 26.04 image directory based on the existing active image
- point the compose example at the Ubuntu 26.04 image and keep the service healthcheck/DinD example updates

## Validation
- `./build_ubuntu_26_04.sh`
- `HOST_HOME=/home/dizzy HOST_KVM_GID=109 docker compose -f docker-compose.example.yml config`
- `git diff --check HEAD~2..HEAD`

Note: this package has no `npm run lint` script.