### PR TITLE
Fix Codex setup in development containers

### DIFF
--- a/image_ubuntu_24_04/Dockerfile
+++ b/image_ubuntu_24_04/Dockerfile
@@ -77,7 +77,8 @@ RUN chmod +x /usr/local/bin/entrypoint.sh && \
   npm install --global npm && \
   echo "Install Codex CLI for dev user" && \
   su dev -c "mkdir -p /home/dev/.local" && \
-  su dev -c "NPM_CONFIG_PREFIX=/home/dev/.local npm install --global @openai/codex" && \
+  su dev -c "npm config set prefix /home/dev/.local" && \
+  su dev -c "npm install --global @openai/codex" && \
   echo "Install Claude CLI via Anthropic's native installer" && \
   su dev -c "curl -fsSL https://claude.ai/install.sh | bash -s latest" && \
   ln -sf /home/dev/.local/bin/claude /usr/local/bin/claude && \

--- a/image_ubuntu_26_04/Dockerfile
+++ b/image_ubuntu_26_04/Dockerfile
@@ -85,7 +85,8 @@ RUN chmod +x /usr/local/bin/entrypoint.sh && \
   npm install --global npm && \
   echo "Install Codex CLI for dev user" && \
   su dev -c "mkdir -p /home/dev/.local" && \
-  su dev -c "NPM_CONFIG_PREFIX=/home/dev/.local npm install --global @openai/codex" && \
+  su dev -c "npm config set prefix /home/dev/.local" && \
+  su dev -c "npm install --global @openai/codex" && \
   echo "Install Claude CLI via Anthropic's native installer" && \
   su dev -c "curl -fsSL https://claude.ai/install.sh | bash -s latest" && \
   ln -sf /home/dev/.local/bin/claude /usr/local/bin/claude && \

--- a/shared/scripts/entrypoint.rb
+++ b/shared/scripts/entrypoint.rb
@@ -18,7 +18,8 @@ end
   "/home/dev/.config/claude",
   "/home/dev/.config/opencode"
 ].each do |config_dir_path|
-  FileUtils.mkdir_p(config_dir_path)
+  next unless File.directory?(config_dir_path)
+
   FileUtils.chown("dev", "dev", config_dir_path)
 end
 

--- a/shared/scripts/entrypoint.rb
+++ b/shared/scripts/entrypoint.rb
@@ -10,6 +10,18 @@ unless File.exist?("/home/dev/.ssh")
   system("find", "/home/dev-sample/", "-mindepth", "1", "-maxdepth", "1", "-exec", "cp", "-rp", "{}", "/home/dev/", ";")
 end
 
+[
+  "/home/dev/.codex",
+  "/home/dev/.claude",
+  "/home/dev/.gemini",
+  "/home/dev/.config",
+  "/home/dev/.config/claude",
+  "/home/dev/.config/opencode"
+].each do |config_dir_path|
+  FileUtils.mkdir_p(config_dir_path)
+  FileUtils.chown("dev", "dev", config_dir_path)
+end
+
 unless File.exist?("/shared/ssh/authorized_keys")
   puts "Copying sample authorized_keys since none exists"
   FileUtils.copy("/shared/ssh/authorized_keys.example", "/shared/ssh/authorized_keys")


### PR DESCRIPTION
## Summary
- ensure mounted agent/tool config parent directories are writable by the `dev` user on container startup
- persist the dev user's npm global prefix before installing Codex so Codex updates target `/home/dev/.local`
- repair the same Codex npm prefix behavior for both Ubuntu image definitions

## Validation
- `ruby -c shared/scripts/entrypoint.rb`
- `git diff --check -- image_ubuntu_24_04/Dockerfile image_ubuntu_26_04/Dockerfile shared/scripts/entrypoint.rb`
- in `ticket-app-1-web-1`: `codex doctor` now reports state paths inspectable and install/update target consistent

Note: `codex doctor` still reports missing credentials in the new `ticket-app-1` home, which is expected until Codex is logged in there or an auth file is intentionally provided.