### PR TITLE
Install AI tooling across Ubuntu images

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ By using a combination of Docker, SSH, SSHFS, XQuartz, Gitg and Regexxer this ca
 sh build.sh
 ```
 
-Maintained Ubuntu images in this repo currently install both `codex` and `claude`. `codex` is installed from npm, while `claude` uses Anthropic's native installer. These images also include companion CLI tools used by those workflows such as `git`, `gh`, `glab`, `ripgrep`, and `ss`.
+Maintained Ubuntu 22.04 and newer images in this repo currently install both `codex` and `claude`. `codex` is installed from npm, while `claude` uses Anthropic's native installer. These images also include companion CLI tools used by those workflows such as `git`, `gh`, `glab`, `ripgrep`, `bubblewrap`, and `ss`.
 
 For the Codex and Claude host mounts in the compose files, copy `.env.example` to `.env` and set `HOST_HOME` to the host user's home directory.
 

--- a/image_ubuntu_22_04/Dockerfile
+++ b/image_ubuntu_22_04/Dockerfile
@@ -13,20 +13,16 @@ ADD .rvmrc /home/dev/.rvmrc
 
 RUN chmod +x /usr/local/bin/entrypoint.sh && \
   apt-get update && apt-get install -y --force-yes apt-utils wget curl && apt-get clean && \
-
 # Locale install
   apt-get update && apt-get install -y --force-yes locales && apt-get clean && \
   locale-gen "en_US.UTF-8" && \
-
 # Postgres tools
   apt-get update && apt-get install -y --force-yes postgresql-client && \
   apt-get clean && \
-
 # Install base apps and packages
   apt-get update && apt-get install -y --force-yes debfoster git gitg nano \
   cron gh openssh-server regexxer ruby ruby-dev git-core screen \
   sudo thunar \
-
 # Codex tools
   git ripgrep sed grep coreutils findutils diffutils \
   gh glab jq curl ca-certificates \
@@ -35,18 +31,14 @@ RUN chmod +x /usr/local/bin/entrypoint.sh && \
   build-essential make pkg-config \
   python3 python3-pip \
   openssh-client rsync tree fd-find bat && \
-
   apt-get clean && \
-
   echo "Configure dev user" && \
   /usr/sbin/useradd -s /bin/bash -m dev && \
   chown dev:dev -R /home/dev && \
   /bin/bash -lc 'echo '\''export PATH="$HOME/.local/bin:$PATH"'\'' >> /home/dev/.profile' && \
   chown dev:dev /home/dev/.profile && \
-
 # Use auth keys to access SSH in shared/ssh/authorized_keys instead of a password
 #   echo "dev:password" | chpasswd && \
-
   echo "Configure SSH" && \
   mkdir /home/dev/.ssh && \
   chmod 700 /home/dev/.ssh && \
@@ -56,33 +48,28 @@ RUN chmod +x /usr/local/bin/entrypoint.sh && \
   mv /etc/ssh/sshd_config /etc/ssh/sshd_config.original && \
   ln -s /shared/ssh/sshd_config /etc/ssh/sshd_config && \
   mkdir /var/run/sshd && \
-
   echo "Install Heroku CLI" && \
   curl https://cli-assets.heroku.com/install-ubuntu.sh | sh && \
-
   echo "Install Java" && \
   apt-get install -y --force-yes software-properties-common && apt-get clean && \
   add-apt-repository ppa:linuxuprising/java && \
   /bin/bash -c "echo debconf shared/accepted-oracle-license-v1-3 select true | debconf-set-selections" && \
   /bin/bash -c "echo debconf shared/accepted-oracle-license-v1-3 seen true | debconf-set-selections" && \
   apt-get update && apt-get install -y --force-yes oracle-java17-installer && apt-get clean && \
-
   echo "Install NodeJS" && \
   curl -fsSL https://deb.nodesource.com/setup_current.x | sudo -E bash - && \
   apt-get update && apt-get install -y --force-yes nodejs && \
-
   echo "Install latest npm" && \
   npm install --global npm && \
   echo "Install Codex CLI for dev user" && \
   su dev -c "mkdir -p /home/dev/.local" && \
-  su dev -c "NPM_CONFIG_PREFIX=/home/dev/.local npm install --global @openai/codex" && \
+  su dev -c "npm config set prefix /home/dev/.local" && \
+  su dev -c "npm install --global @openai/codex" && \
   echo "Install Claude CLI via Anthropic's native installer" && \
   su dev -c "curl -fsSL https://claude.ai/install.sh | bash -s latest" && \
   ln -sf /home/dev/.local/bin/claude /usr/local/bin/claude && \
-
   echo "Install Yarn" && \
   npm install --global yarn && \
-
 # Build deps for the Ruby and various gems
   apt-get update && apt-get install -y --force-yes build-essential automake bison autoconf pkg-config \
   openssl libssl-dev zlib1g zlib1g-dev libyaml-dev git-core curl gawk g++ gcc make \
@@ -91,15 +78,12 @@ RUN chmod +x /usr/local/bin/entrypoint.sh && \
   libsqlite3-dev sqlite3 libpq-dev libqt5webkit5-dev gstreamer1.0-plugins-base \
   gstreamer1.0-tools gstreamer1.0-x libcurl4-openssl-dev xvfb firefox && \
   apt-get clean && \
-
 # ActiveStorage preview stuff
   apt-get update && apt-get install -y ffmpeg libpoppler-glib-dev libvips42 poppler-utils && \
-
 # Install RVM
   apt-get install -y --force-yes dirmngr && \
   su dev -c "gpg --keyserver keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB" && \
   su dev -c "curl -sSL https://get.rvm.io | bash" && \
-
   echo "Install Chrome" && \
   apt-get install -y --force-yes libxss1 libappindicator1 libindicator7 && \
   wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
@@ -107,7 +91,6 @@ RUN chmod +x /usr/local/bin/entrypoint.sh && \
   apt-get install -f -y --force-yes && \
   apt-get clean && \
   rm google-chrome-stable_current_amd64.deb && \
-
   echo "Install ChromeDriver" && \
   apt-get install -y --force-yes fonts-liberation unzip xdg-utils && \
   apt-get clean && \
@@ -117,9 +100,7 @@ RUN chmod +x /usr/local/bin/entrypoint.sh && \
   mv -f ~/chromedriver /usr/local/bin/chromedriver && \
   chown root:root /usr/local/bin/chromedriver && \
   chmod 0755 /usr/local/bin/chromedriver && \
-
   echo "Preparing home dir to be moved into mount on first boot" && \
   mv /home/dev /home/dev-sample
-
 # Add the entrypoint
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/image_ubuntu_24_10/Dockerfile
+++ b/image_ubuntu_24_10/Dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu:24.10
 ENV LANGUAGE=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
 ENV LANG=en_US.UTF-8
+ENV PATH=/home/dev/.local/bin:$PATH
 ENV DEBIAN_FRONTEND=noninteractive
 
 ADD entrypoint.sh /usr/local/bin/entrypoint.sh
@@ -13,35 +14,38 @@ ADD .rvmrc /home/dev/.rvmrc
 
 RUN chmod +x /usr/local/bin/entrypoint.sh && \
   apt-get update && apt-get install -y --force-yes apt-utils wget curl && apt-get clean && \
-
 # Locale install
   apt-get update && apt-get install -y --force-yes locales && apt-get clean && \
   locale-gen "en_US.UTF-8" && \
-
 # Postgres tools
   apt-get update && apt-get install -y --force-yes postgresql-client && \
   apt-get clean && \
-
 # Install base apps and packages
   apt-get update && apt-get install -y --force-yes debfoster git gitg nano \
   cron openssh-server regexxer software-properties-common ruby ruby-dev git-core screen \
-  sudo thunar && \
+  sudo thunar \
+# Codex tools
+  git ripgrep sed grep coreutils findutils diffutils \
+  gh glab jq curl ca-certificates \
+  less file procps iproute2 \
+  tar gzip bzip2 xz-utils unzip zip bubblewrap \
+  build-essential make pkg-config \
+  python3 python3-pip \
+  openssh-client rsync tree fd-find bat && \
   apt-get clean && \
   deluser --remove-home ubuntu && \
-
 # Firefox
   add-apt-repository ppa:mozillateam/ppa && \
   apt-get update && apt-get install -y --force-yes firefox && \
   apt-get clean && \
-
 # Dev user
   echo "Configure dev user" && \
   /usr/sbin/useradd -s /bin/bash -m dev && \
   chown dev:dev -R /home/dev && \
-
+  /bin/bash -lc 'echo '\''export PATH="$HOME/.local/bin:$PATH"'\'' >> /home/dev/.profile' && \
+  chown dev:dev /home/dev/.profile && \
 # Use auth keys to access SSH in shared/ssh/authorized_keys instead of a password
 #   echo "dev:password" | chpasswd && \
-
   echo "Configure SSH" && \
   mkdir /home/dev/.ssh && \
   chmod 700 /home/dev/.ssh && \
@@ -50,11 +54,9 @@ RUN chmod +x /usr/local/bin/entrypoint.sh && \
   ln -s /shared/ssh/authorized_keys /home/dev/.ssh/authorized_keys && \
   mv /etc/ssh/sshd_config /etc/ssh/sshd_config.original && \
   ln -s /shared/ssh/sshd_config /etc/ssh/sshd_config && \
-
 # Heroku CLI doesn't support 24.10 yet
 #  echo "Install Heroku CLI" && \
 #   curl https://cli-assets.heroku.com/install-ubuntu.sh | sh && \
-
 # This repo doesn't have a 24.10 version yet
 #  echo "Install Java" && \
 #  apt-get install -y --force-yes software-properties-common && apt-get clean && \
@@ -62,14 +64,20 @@ RUN chmod +x /usr/local/bin/entrypoint.sh && \
 #  /bin/bash -c "echo debconf shared/accepted-oracle-license-v1-3 select true | debconf-set-selections" && \
 #  /bin/bash -c "echo debconf shared/accepted-oracle-license-v1-3 seen true | debconf-set-selections" && \
 #  apt-get update && apt-get install -y --force-yes oracle-java17-installer && apt-get clean && \
-
   echo "Install NodeJS" && \
   curl -fsSL https://deb.nodesource.com/setup_current.x | sudo -E bash - && \
   apt-get update && apt-get install -y --force-yes nodejs && \
-
+  echo "Install latest npm" && \
+  npm install --global npm && \
+  echo "Install Codex CLI for dev user" && \
+  su dev -c "mkdir -p /home/dev/.local" && \
+  su dev -c "npm config set prefix /home/dev/.local" && \
+  su dev -c "npm install --global @openai/codex" && \
+  echo "Install Claude CLI via Anthropic's native installer" && \
+  su dev -c "curl -fsSL https://claude.ai/install.sh | bash -s latest" && \
+  ln -sf /home/dev/.local/bin/claude /usr/local/bin/claude && \
   echo "Install Yarn" && \
   npm install --global yarn && \
-
 # Build deps for the Ruby and various gems
   apt-get update && apt-get install -y --force-yes build-essential automake bison autoconf pkg-config \
   openssl libssl-dev zlib1g zlib1g-dev libyaml-dev git-core curl gawk g++ gcc make \
@@ -78,15 +86,12 @@ RUN chmod +x /usr/local/bin/entrypoint.sh && \
   libsqlite3-dev sqlite3 libpq-dev libqt5webkit5-dev gstreamer1.0-plugins-base \
   gstreamer1.0-tools gstreamer1.0-x libcurl4-openssl-dev xvfb firefox-geckodriver && \
   apt-get clean && \
-
 # ActiveStorage preview stuff
   apt-get update && apt-get install -y ffmpeg libpoppler-glib-dev libvips42 poppler-utils && \
-
 # Install RVM
   apt-get install -y --force-yes dirmngr && \
   su dev -c "gpg --keyserver keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB" && \
   su dev -c "curl -sSL https://get.rvm.io | bash" && \
-
   echo "Install Chrome" && \
   apt-get install -y --force-yes libxss1 libindicator7 && \
   wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
@@ -94,7 +99,6 @@ RUN chmod +x /usr/local/bin/entrypoint.sh && \
   apt-get install -f -y --force-yes && \
   apt-get clean && \
   rm google-chrome-stable_current_amd64.deb && \
-
   echo "Install ChromeDriver" && \
   apt-get install -y --force-yes fonts-liberation unzip xdg-utils && \
   apt-get clean && \
@@ -104,9 +108,7 @@ RUN chmod +x /usr/local/bin/entrypoint.sh && \
   mv -f ~/chromedriver /usr/local/bin/chromedriver && \
   chown root:root /usr/local/bin/chromedriver && \
   chmod 0755 /usr/local/bin/chromedriver && \
-
   echo "Preparing home dir to be moved into mount on first boot" && \
   mv /home/dev /home/dev-sample
-
 # Add the entrypoint
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/image_ubuntu_25_04/Dockerfile
+++ b/image_ubuntu_25_04/Dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu:25.04
 ENV LANGUAGE=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
 ENV LANG=en_US.UTF-8
+ENV PATH=/home/dev/.local/bin:$PATH
 ENV DEBIAN_FRONTEND=noninteractive
 
 ADD entrypoint.sh /usr/local/bin/entrypoint.sh
@@ -13,44 +14,38 @@ ADD .rvmrc /home/dev/.rvmrc
 
 RUN chmod +x /usr/local/bin/entrypoint.sh && \
   apt-get update && apt-get install -y --force-yes apt-utils wget curl && apt-get clean && \
-
 # Locale install
   apt-get update && apt-get install -y --force-yes locales && apt-get clean && \
   locale-gen "en_US.UTF-8" && \
-
 # Postgres tools
   apt-get update && apt-get install -y --force-yes postgresql-client && \
   apt-get clean && \
-
 # Install base apps and packages
   apt-get update && apt-get install -y --force-yes debfoster git gitg nano \
   cron openssh-server regexxer software-properties-common ruby ruby-dev git-core screen \
-  sudo thunar && \
-  apt-get clean && \
-  deluser --remove-home ubuntu \
-
+  sudo thunar \
 # Codex tools
   git ripgrep sed grep coreutils findutils diffutils \
-  jq curl ca-certificates \
-  less file procps \
-  tar gzip bzip2 xz-utils unzip zip \
+  gh glab jq curl ca-certificates \
+  less file procps iproute2 \
+  tar gzip bzip2 xz-utils unzip zip bubblewrap \
   build-essential make pkg-config \
   python3 python3-pip \
   openssh-client rsync tree fd-find bat && \
-
+  apt-get clean && \
+  deluser --remove-home ubuntu && \
 # Firefox
   add-apt-repository ppa:mozillateam/ppa && \
   apt-get update && apt-get install -y --force-yes firefox && \
   apt-get clean && \
-
 # Dev user
   echo "Configure dev user" && \
   /usr/sbin/useradd -s /bin/bash -m dev && \
   chown dev:dev -R /home/dev && \
-
+  /bin/bash -lc 'echo '\''export PATH="$HOME/.local/bin:$PATH"'\'' >> /home/dev/.profile' && \
+  chown dev:dev /home/dev/.profile && \
 # Use auth keys to access SSH in shared/ssh/authorized_keys instead of a password
 #   echo "dev:password" | chpasswd && \
-
   echo "Configure SSH" && \
   mkdir /home/dev/.ssh && \
   chmod 700 /home/dev/.ssh && \
@@ -59,11 +54,9 @@ RUN chmod +x /usr/local/bin/entrypoint.sh && \
   ln -s /shared/ssh/authorized_keys /home/dev/.ssh/authorized_keys && \
   mv /etc/ssh/sshd_config /etc/ssh/sshd_config.original && \
   ln -s /shared/ssh/sshd_config /etc/ssh/sshd_config && \
-
 # Heroku CLI doesn't support 24.10 yet
 #  echo "Install Heroku CLI" && \
 #   curl https://cli-assets.heroku.com/install-ubuntu.sh | sh && \
-
 # This repo doesn't have a 24.10 version yet
 #  echo "Install Java" && \
 #  apt-get install -y --force-yes software-properties-common && apt-get clean && \
@@ -71,14 +64,20 @@ RUN chmod +x /usr/local/bin/entrypoint.sh && \
 #  /bin/bash -c "echo debconf shared/accepted-oracle-license-v1-3 select true | debconf-set-selections" && \
 #  /bin/bash -c "echo debconf shared/accepted-oracle-license-v1-3 seen true | debconf-set-selections" && \
 #  apt-get update && apt-get install -y --force-yes oracle-java17-installer && apt-get clean && \
-
   echo "Install NodeJS" && \
   curl -fsSL https://deb.nodesource.com/setup_current.x | sudo -E bash - && \
   apt-get update && apt-get install -y --force-yes nodejs && \
-
+  echo "Install latest npm" && \
+  npm install --global npm && \
+  echo "Install Codex CLI for dev user" && \
+  su dev -c "mkdir -p /home/dev/.local" && \
+  su dev -c "npm config set prefix /home/dev/.local" && \
+  su dev -c "npm install --global @openai/codex" && \
+  echo "Install Claude CLI via Anthropic's native installer" && \
+  su dev -c "curl -fsSL https://claude.ai/install.sh | bash -s latest" && \
+  ln -sf /home/dev/.local/bin/claude /usr/local/bin/claude && \
   echo "Install Yarn" && \
   npm install --global yarn && \
-
 # Build deps for the Ruby and various gems
   apt-get update && apt-get install -y --force-yes build-essential automake bison autoconf pkg-config \
   openssl libssl-dev zlib1g zlib1g-dev libyaml-dev git-core curl gawk g++ gcc make \
@@ -87,15 +86,12 @@ RUN chmod +x /usr/local/bin/entrypoint.sh && \
   libsqlite3-dev sqlite3 libpq-dev gstreamer1.0-plugins-base \
   gstreamer1.0-tools gstreamer1.0-x libcurl4-openssl-dev xvfb firefox-geckodriver && \
   apt-get clean && \
-
 # ActiveStorage preview stuff
   apt-get update && apt-get install -y ffmpeg libpoppler-glib-dev libvips42 poppler-utils && \
-
 # Install RVM
   apt-get install -y --force-yes dirmngr && \
   su dev -c "gpg --keyserver keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB" && \
   su dev -c "curl -sSL https://get.rvm.io | bash" && \
-
   echo "Install Chrome" && \
   apt-get install -y --force-yes libxss1 libindicator7 && \
   wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
@@ -103,7 +99,6 @@ RUN chmod +x /usr/local/bin/entrypoint.sh && \
   apt-get install -f -y --force-yes && \
   apt-get clean && \
   rm google-chrome-stable_current_amd64.deb && \
-
   echo "Install ChromeDriver" && \
   apt-get install -y --force-yes fonts-liberation unzip xdg-utils && \
   apt-get clean && \
@@ -113,9 +108,7 @@ RUN chmod +x /usr/local/bin/entrypoint.sh && \
   mv -f ~/chromedriver /usr/local/bin/chromedriver && \
   chown root:root /usr/local/bin/chromedriver && \
   chmod 0755 /usr/local/bin/chromedriver && \
-
   echo "Preparing home dir to be moved into mount on first boot" && \
   mv /home/dev /home/dev-sample
-
 # Add the entrypoint
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/image_ubuntu_25_10/Dockerfile
+++ b/image_ubuntu_25_10/Dockerfile
@@ -14,20 +14,16 @@ ADD .rvmrc /home/dev/.rvmrc
 
 RUN chmod +x /usr/local/bin/entrypoint.sh && \
   apt-get update && apt-get install -y --force-yes apt-utils wget curl && apt-get clean && \
-
 # Locale install
   apt-get update && apt-get install -y --force-yes locales && apt-get clean && \
   locale-gen "en_US.UTF-8" && \
-
 # Postgres tools
   apt-get update && apt-get install -y --force-yes postgresql-client && \
   apt-get clean && \
-
 # Install base apps and packages
   apt-get update && apt-get install -y --force-yes debfoster git gitg nano \
   cron openssh-server regexxer software-properties-common ruby ruby-dev git-core screen \
   sudo thunar \
-
 # Codex tools
   git ripgrep sed grep coreutils findutils diffutils \
   gh glab jq curl ca-certificates \
@@ -36,26 +32,20 @@ RUN chmod +x /usr/local/bin/entrypoint.sh && \
   build-essential make pkg-config \
   python3 python3-pip \
   openssh-client rsync tree fd-find bat && \
-
   apt-get clean && \
   deluser --remove-home ubuntu && \
-
-
 # Firefox
   add-apt-repository ppa:mozillateam/ppa && \
   apt-get update && apt-get install -y --force-yes firefox && \
   apt-get clean && \
-
 # Dev user
   echo "Configure dev user" && \
   /usr/sbin/useradd -s /bin/bash -m dev && \
   chown dev:dev -R /home/dev && \
   /bin/bash -lc 'echo '\''export PATH="$HOME/.local/bin:$PATH"'\'' >> /home/dev/.profile' && \
   chown dev:dev /home/dev/.profile && \
-
 # Use auth keys to access SSH in shared/ssh/authorized_keys instead of a password
 #   echo "dev:password" | chpasswd && \
-
   echo "Configure SSH" && \
   mkdir /home/dev/.ssh && \
   chmod 700 /home/dev/.ssh && \
@@ -64,11 +54,9 @@ RUN chmod +x /usr/local/bin/entrypoint.sh && \
   ln -s /shared/ssh/authorized_keys /home/dev/.ssh/authorized_keys && \
   mv /etc/ssh/sshd_config /etc/ssh/sshd_config.original && \
   ln -s /shared/ssh/sshd_config /etc/ssh/sshd_config && \
-
 # Heroku CLI doesn't support 24.10 yet
 #  echo "Install Heroku CLI" && \
 #   curl https://cli-assets.heroku.com/install-ubuntu.sh | sh && \
-
 # This repo doesn't have a 24.10 version yet
 #  echo "Install Java" && \
 #  apt-get install -y --force-yes software-properties-common && apt-get clean && \
@@ -76,23 +64,20 @@ RUN chmod +x /usr/local/bin/entrypoint.sh && \
 #  /bin/bash -c "echo debconf shared/accepted-oracle-license-v1-3 select true | debconf-set-selections" && \
 #  /bin/bash -c "echo debconf shared/accepted-oracle-license-v1-3 seen true | debconf-set-selections" && \
 #  apt-get update && apt-get install -y --force-yes oracle-java17-installer && apt-get clean && \
-
   echo "Install NodeJS" && \
   curl -fsSL https://deb.nodesource.com/setup_current.x | sudo -E bash - && \
   apt-get update && apt-get install -y --force-yes nodejs && \
-
   echo "Install latest npm" && \
   npm install --global npm && \
   echo "Install Codex CLI for dev user" && \
   su dev -c "mkdir -p /home/dev/.local" && \
-  su dev -c "NPM_CONFIG_PREFIX=/home/dev/.local npm install --global @openai/codex" && \
+  su dev -c "npm config set prefix /home/dev/.local" && \
+  su dev -c "npm install --global @openai/codex" && \
   echo "Install Claude CLI via Anthropic's native installer" && \
   su dev -c "curl -fsSL https://claude.ai/install.sh | bash -s latest" && \
   ln -sf /home/dev/.local/bin/claude /usr/local/bin/claude && \
-
   echo "Install Yarn" && \
   npm install --global yarn && \
-
 # Build deps for the Ruby and various gems
   apt-get update && apt-get install -y --force-yes build-essential automake bison autoconf pkg-config \
   openssl libssl-dev zlib1g zlib1g-dev libyaml-dev git-core curl gawk g++ gcc make \
@@ -101,15 +86,12 @@ RUN chmod +x /usr/local/bin/entrypoint.sh && \
   libsqlite3-dev sqlite3 libpq-dev gstreamer1.0-plugins-base \
   gstreamer1.0-tools gstreamer1.0-x libcurl4-openssl-dev xvfb firefox-geckodriver && \
   apt-get clean && \
-
 # ActiveStorage preview stuff
   apt-get update && apt-get install -y ffmpeg libpoppler-glib-dev libvips42 poppler-utils && \
-
 # Install RVM
   apt-get install -y --force-yes dirmngr && \
   su dev -c "gpg --keyserver keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB" && \
   su dev -c "curl -sSL https://get.rvm.io | bash" && \
-
   echo "Install Chrome" && \
   apt-get install -y --force-yes libxss1 libindicator7 && \
   wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
@@ -117,7 +99,6 @@ RUN chmod +x /usr/local/bin/entrypoint.sh && \
   apt-get install -f -y --force-yes && \
   apt-get clean && \
   rm google-chrome-stable_current_amd64.deb && \
-
   echo "Install ChromeDriver" && \
   apt-get install -y --force-yes fonts-liberation unzip xdg-utils && \
   apt-get clean && \
@@ -127,9 +108,7 @@ RUN chmod +x /usr/local/bin/entrypoint.sh && \
   mv -f ~/chromedriver /usr/local/bin/chromedriver && \
   chown root:root /usr/local/bin/chromedriver && \
   chmod 0755 /usr/local/bin/chromedriver && \
-
   echo "Preparing home dir to be moved into mount on first boot" && \
   mv /home/dev /home/dev-sample
-
 # Add the entrypoint
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
## Summary
- add the Codex/Claude tooling pattern to the Ubuntu 24.10 and 25.04 Dockerfiles
- make Codex's npm prefix persistent for Ubuntu 22.04 and 25.10 so `codex` stays on `/home/dev/.local/bin`
- document that maintained Ubuntu 22.04+ images include Codex, Claude, bubblewrap, and companion CLI tools
- remove empty continuation lines in touched Dockerfiles so Dockerfile checks pass

## Validation
- `docker build --check -f image_ubuntu_22_04/Dockerfile image_ubuntu_22_04`
- `docker build --check -f image_ubuntu_24_10/Dockerfile image_ubuntu_24_10`
- `docker build --check -f image_ubuntu_25_04/Dockerfile image_ubuntu_25_04`
- `docker build --check -f image_ubuntu_25_10/Dockerfile image_ubuntu_25_10`
- `git diff --check -- README.md image_ubuntu_22_04/Dockerfile image_ubuntu_24_10/Dockerfile image_ubuntu_25_04/Dockerfile image_ubuntu_25_10/Dockerfile`